### PR TITLE
configmgr: fix missing mixer_update_ctls() method

### DIFF
--- a/configmgr/audio_config.c
+++ b/configmgr/audio_config.c
@@ -334,7 +334,7 @@ static int ctl_open(struct config_mgr *cm, struct ctl *pctl)
         /* Update tinyalsa with any new controls that have been added
          * and try again
          */
-        mixer_update_ctls(cm->mixer);
+        mixer_add_new_ctls(cm->mixer);
         ctl = mixer_get_ctl_by_name(cm->mixer, pctl->name);
     }
 


### PR DESCRIPTION
Commit fd3290357ea02f871a10eec208697fb97d578fe6 in tinyalsa introduced
a new mixer_add_new_ctls() method, and tinyhal was instead depending
on the old name given to it during development, mixer_update_ctls().

E.g.:
    device/linaro/generic/audio/audio_config.c:337:9: error: implicit declaration of function 'mixer_update_ctls' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
            mixer_update_ctls(cm->mixer);
            ^
    device/linaro/generic/audio/audio_config.c:337:9: note: did you mean 'mixer_add_new_ctls'?
    external/tinyalsa/include/tinyalsa/mixer.h:75:5: note: 'mixer_add_new_ctls' declared here
    int mixer_add_new_ctls(struct mixer *mixer);
        ^
    1 error generated.
    ninja: build stopped: subcommand failed.
    build/core/ninja.mk:148: recipe for target 'ninja_wrapper' failed
    make: *** [ninja_wrapper] Error 1