### PR TITLE
Updates to fix build warnings

### DIFF
--- a/audio/Android.mk
+++ b/audio/Android.mk
@@ -28,7 +28,7 @@ else
 LOCAL_MODULE := audio.$(strip $(TINYHAL_AUDIO_MODULE_NAME)).$(TARGET_DEVICE)
 endif
 
-LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/hw
+LOCAL_MODULE_RELATIVE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)/hw
 LOCAL_MODULE_TAGS := optional
 
 LOCAL_CFLAGS += -Werror -Wno-error=unused-parameter -Wno-unused-parameter

--- a/audio/audio_hw.c
+++ b/audio/audio_hw.c
@@ -767,7 +767,7 @@ static ssize_t out_pcm_write(struct audio_stream_out *stream, const void* buffer
         out->common.standby = false;
     }
 
-    ret = pcm_write(out->pcm, buffer, bytes);
+    ret = pcm_writei(out->pcm, buffer, bytes);
     if (ret >= 0) {
         ret = bytes;
     }
@@ -1469,11 +1469,11 @@ static int get_next_buffer(struct resampler_buffer_provider *buffer_provider,
     }
 
     if (rsp->frames_in == 0) {
-        rsp->read_status = pcm_read(in->pcm,
-                                   (void*)rsp->buffer,
-                                   rsp->in_buffer_size);
+        rsp->read_status = pcm_readi(in->pcm,
+                                     (void*)rsp->buffer,
+                                     rsp->in_buffer_size);
         if (rsp->read_status != 0) {
-            ALOGE("get_next_buffer() pcm_read error %d", errno);
+            ALOGE("get_next_buffer() pcm_readi error %d", errno);
             buffer->raw = NULL;
             buffer->frame_count = 0;
             return rsp->read_status;
@@ -2136,7 +2136,7 @@ static ssize_t do_in_pcm_read(struct audio_stream_in *stream, void* buffer,
     if (in->resampler.resampler != NULL) {
         ret = read_resampled_frames(in, buffer, frames_rq);
     } else {
-        ret = pcm_read(in->pcm, buffer, bytes);
+        ret = pcm_readi(in->pcm, buffer, bytes);
     }
 
     /* Assume any non-negative return is a successful read */

--- a/audio/audio_hw.c
+++ b/audio/audio_hw.c
@@ -742,7 +742,7 @@ static int out_pcm_standby(struct audio_stream *stream)
 static ssize_t out_pcm_write(struct audio_stream_out *stream, const void* buffer,
                          size_t bytes)
 {
-    ALOGV("+out_pcm_write(%p) l=%u", stream, bytes);
+    ALOGV("+out_pcm_write(%p) l=%zu", stream, bytes);
 
     int ret = 0;
     struct stream_out_pcm *out = (struct stream_out_pcm *)stream;
@@ -910,7 +910,7 @@ static ssize_t out_compress_write(struct audio_stream_out *stream,
     struct stream_out_compress *out = (struct stream_out_compress *)stream;
     int ret = 0;
 
-    ALOGV("out_compress_write(%p) %u", stream, bytes);
+    ALOGV("out_compress_write(%p) %zu", stream, bytes);
 
     ret = open_output_compress(out);
 
@@ -1292,7 +1292,7 @@ static int in_set_format(struct audio_stream *stream, audio_format_t format)
 static size_t in_get_buffer_size(const struct audio_stream *stream)
 {
     const struct stream_in_common *in = (struct stream_in_common *)stream;
-    ALOGV("in_get_buffer_size(%p): %u", stream, in->buffer_size );
+    ALOGV("in_get_buffer_size(%p): %zu", stream, in->buffer_size );
     return in->buffer_size;
 }
 
@@ -1828,7 +1828,7 @@ static ssize_t do_in_compress_pcm_read(struct audio_stream_in *stream, void* buf
     struct audio_device *adev = in->common.dev;
     int ret = 0;
 
-    ALOGV("+do_in_compress_pcm_read %d", bytes);
+    ALOGV("+do_in_compress_pcm_read %zu", bytes);
 
     pthread_mutex_lock(&in->common.lock);
     ret = start_compress_pcm_input_stream(in);
@@ -1988,7 +1988,7 @@ static int do_open_pcm_input(struct stream_in_pcm *in)
 
     in_pcm_fill_params( in, &config );
 
-    ALOGV("input buffer size=0x%x", in->common.buffer_size);
+    ALOGV("input buffer size=0x%zx", in->common.buffer_size);
 
     /*
      * If the stream rate differs from the PCM rate, we need to
@@ -2124,7 +2124,7 @@ static ssize_t do_in_pcm_read(struct audio_stream_in *stream, void* buffer,
     struct audio_device *adev = in->common.dev;
     size_t frames_rq = bytes / in->common.frame_size;
 
-    ALOGV("+do_in_pcm_read %d", bytes);
+    ALOGV("+do_in_pcm_read %zu", bytes);
 
     pthread_mutex_lock(&in->common.lock);
     ret = start_pcm_input_stream(in);

--- a/audio/audio_hw.c
+++ b/audio/audio_hw.c
@@ -1353,7 +1353,7 @@ static void do_in_set_read_timestamp(struct stream_in_common *in)
  */
 static void do_in_realtime_delay(struct stream_in_common *in, size_t bytes)
 {
-    size_t required_interval;
+    nsecs_t required_interval;
     nsecs_t required_ns;
     nsecs_t elapsed_ns;
     struct timespec ts;

--- a/configmgr/Android.mk
+++ b/configmgr/Android.mk
@@ -20,7 +20,7 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := libaudiohalcm
-LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)
+LOCAL_MODULE_RELATIVE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)
 LOCAL_MODULE_TAGS := eng
 
 LOCAL_CFLAGS += -Werror -Wno-error=unused-parameter -Wno-unused-parameter


### PR DESCRIPTION
Fix some type compatibility warnings in 64-bit builds and use the new pcm_[read|write]i functions