### PR TITLE
Provide support the mixer_paths xml format for configuring audio routing

### DIFF
--- a/audio.example.xml
+++ b/audio.example.xml
@@ -75,6 +75,14 @@ property ro.product.device
             <ctl name="Jack Enable" val="0"/>
             <ctl name="Codec Config" index="8" val="0x7f,0x54,0xaa,0xaa"/>
 
+            <!-- A path to the mixer_paths file to use the ctl values from
+            the mixer_paths xml format.
+            This entry must have these attribute
+                path - path to the mixer_paths.xml file
+            -->
+
+            <mixer_paths path="/vendor/etc/mixer_paths.xml" />
+
         </init>
         </mixer>
 

--- a/configmgr/Android.mk
+++ b/configmgr/Android.mk
@@ -29,6 +29,8 @@ LOCAL_C_INCLUDES += \
 	external/tinycompress/include \
 	external/tinyalsa/include \
 	external/expat/lib \
+	system/media/audio_effects/include \
+	system/media/audio_route/include \
 	$(call include-path-for, audio-utils)
 
 
@@ -43,6 +45,7 @@ LOCAL_SHARED_LIBRARIES := \
 	libhardware \
 	libexpat	\
 	libtinyalsa	\
+	libaudioroute \
 
 ifeq ($(strip $(TINYALSA_NO_ADD_NEW_CTRLS)),true)
 LOCAL_CFLAGS += -DTINYALSA_NO_ADD_NEW_CTRLS


### PR DESCRIPTION
Many AOSP projects use the mixer_paths xml format to configure audio routing. Support for this format will help use tinyhal in projects using the mixer_paths xml format.

Add parser for the mixer_paths files using the audioroute library.
Add the <mixer_paths> element for parsing, which takes the name of the
mixer_paths.xml file.
Update audio.example.xml with an example of using <mixer_paths>
to configure audio routing.