### PR TITLE
tinyhal: audio: Impl channel adjustment for input sound flow

### DIFF
--- a/audio/Android.mk
+++ b/audio/Android.mk
@@ -76,6 +76,10 @@ ifeq ($(strip $(TINYHAL_COMPRESS_PLAYBACK)),true)
 LOCAL_CFLAGS += -DTINYHAL_COMPRESS_PLAYBACK
 endif
 
+ifeq ($(TARGET_DEVICE),kingfisher)
+LOCAL_CFLAGS += -DPLATFORM_RCAR3
+endif
+
 include $(BUILD_SHARED_LIBRARY)
 
 endif


### PR DESCRIPTION
Hello.

We have detected the issue on RCAR3 platform where high level applications can not capture a sound through Tinyhal with requested channel count less than 8. This occurs because the min-max interval for allowed channel count values
is set to [8..8] in 'pcm3168a' driver, so pcm_open() function returns error in case requested count != 8.
But only AUDIO_CHANNEL_IN_MONO & AUDIO_CHANNEL_IN_STEREO channel masks are supported by functionality in alsa_device_profile.c file ('alsa_utils' directory).
So it is required to apply the current patch, which provides a channel adjustment for input sound by converting the N-channel flow (N - supported by driver) to requested Mono or Stereo flow.
When this patch is merged, we will be able to fix described problem just by a setting IN_CHANNEL_COUNT_DEFAULT and 
'in->hw_channel_count' to the value N supported by our driver.